### PR TITLE
extend only the result instance's eigenclass, not all instances of that instance's type

### DIFF
--- a/lib/bitbucket_rest_api/response/helpers.rb
+++ b/lib/bitbucket_rest_api/response/helpers.rb
@@ -6,15 +6,8 @@ module BitBucket
   class Response::Helpers < Response
 
     def on_complete(env)
-      env[:body].class.class_eval <<-RUBY_EVAL, __FILE__, __LINE__ + 1
-        include BitBucket::Result
-
-        def env
-          @env
-        end
-
-      RUBY_EVAL
-      env[:body].instance_eval { @env = env }
+      env[:body].extend BitBucket::Result
+      env[:body].define_singleton_method(:env) { env }
     end
 
   end # Response::Helpers


### PR DESCRIPTION
So basically, bitbucket extends EVERY INSTANCE OF THE CLASS OF env[:body]. So, in our case, env[:body] is sometimes a string or an array, and from then on, ANY string will have bitbucket result methods.

This patch will only extend the eigenclass of the instance, meaning only that instance will have the methods, not all instances of the same class.
