### PR TITLE
Honor connection_options

### DIFF
--- a/lib/bitbucket_rest_api/connection.rb
+++ b/lib/bitbucket_rest_api/connection.rb
@@ -30,7 +30,8 @@ module BitBucket
           },
           :ssl => { :verify => false },
           :url => options.fetch(:endpoint) { BitBucket.endpoint }
-      }.merge(options)
+      }.merge(BitBucket.connection_options)
+      .merge(options)
     end
 
     # Default middleware stack that uses default adapter as specified at


### PR DESCRIPTION
While researching using proxies with the Bitbucket gem, I noticed that the gem supports specifying connection options, but it does not use those options when creating a connection. This PR addresses that issue.

